### PR TITLE
replaces execSync with sync-exec

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,7 +7,7 @@ var _s = require('underscore.string');
 var fs = require('fs-extra');
 var shared = require('../shared.js');
 var settings = {};
-var sh = require('execSync');
+var sh = require('sync-exec');
 
 
 var NorthGenerator = yeoman.generators.Base.extend({

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "chalk": "~0.4.0",
-    "execSync": "^1.0.2",
+    "sync-exec": "~0.5.0",
     "fs-extra": "^0.10.0",
     "inquirer": "^0.4.1",
     "lodash": "~1.3.1",


### PR DESCRIPTION
@Snugug trying to fix this error:

module.js:338
    throw err;
    ^
Error: Cannot find module './build/Release/shell'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/generator-north/node_modules/execSync/index.js:30:11)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
